### PR TITLE
Fix site background color

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="antialiased bg-white text-zinc-950 dark:bg-zinc-950 dark:text-zinc-50">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -11,7 +11,7 @@
     <%= javascript_importmap_tags %>
     <%= yield :head %>
   </head>
-  <body class="w-full font-sans antialiased bg-white text-zinc-950 scroll-smooth dark:bg-zinc-950 dark:text-zinc-50">
+  <body class="w-full font-sans scroll-smooth">
     <%= render Header.new %>
     <main class="max-w-3xl px-4 mx-auto">
       <% if notice %>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,11 +1,12 @@
-<html>
+<!DOCTYPE html>
+<html lang="en" class="antialiased bg-white text-zinc-950 dark:bg-zinc-950 dark:text-zinc-50">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   </head>
-  <body class="w-full font-sans antialiased bg-white text-zinc-950 scroll-smooth dark:bg-zinc-950 dark:text-zinc-50">
+  <body class="w-full font-sans scroll-smooth">
     <main>
       <%= yield %>
     </main>

--- a/app/views/layouts/preview.html.erb
+++ b/app/views/layouts/preview.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="antialiased bg-white text-zinc-950 dark:bg-zinc-950 dark:text-zinc-50">
   <head>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -8,7 +8,7 @@
     <%= stylesheet_link_tag "application.rouge", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-  <body class="w-full p-8 font-sans antialiased text-zinc-950 bg-zinc-50 scroll-smooth dark:bg-zinc-950 dark:text-zinc-50">
+  <body class="w-full font-sans scroll-smooth">
     <%= yield %>
   </body>
 </html>


### PR DESCRIPTION
When over scrolling, the page was showing a white background in dark mode. Moved the background settings to the HTML tag.